### PR TITLE
ci: update error message for version prefix validation

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -49,7 +49,7 @@ jobs:
           echo "VERSION_FILE_PREFIX: $VERSION_FILE_PREFIX"
           
           if [ "$VERSION_FILE_PREFIX" != "$VERSION_PREFIX" ]; then
-            echo "::error::Version prefix in csproj file ($VERSION_FILE_PREFIX) does not match witch the determined version prefix from branch name ($VERSION_PREFIX)."
+            echo "::error::Version prefix in 'Version.props' file ($VERSION_FILE_PREFIX) does not match witch the determined version prefix from branch name ($VERSION_PREFIX)."
             exit 1
           fi
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,7 +58,7 @@ jobs:
           echo "VERSION_FILE_PREFIX: $VERSION_FILE_PREFIX"
 
           if [ "$VERSION_FILE_PREFIX" != "$VERSION_PREFIX" ]; then
-            echo "::error::Version prefix in csproj file ($VERSION_FILE_PREFIX) does not match witch the determined version prefix from branch name ($VERSION_PREFIX)."
+            echo "::error::Version prefix in 'Version.props' file ($VERSION_FILE_PREFIX) does not match witch the determined version prefix from branch name ($VERSION_PREFIX)."
             exit 1
           fi
 


### PR DESCRIPTION
- Clarified error message to specify 'Version.props' file instead of csproj file.